### PR TITLE
Support symbolic links

### DIFF
--- a/ampy/cli.py
+++ b/ampy/cli.py
@@ -238,7 +238,7 @@ def put(local, remote):
         # Directory copy, create the directory and walk all children to copy
         # over the files.
         board_files = files.Files(_board)
-        for parent, child_dirs, child_files in os.walk(local):
+        for parent, child_dirs, child_files in os.walk(local, followlinks=True):
             # Create board filesystem absolute path to parent directory.
             remote_parent = posixpath.normpath(
                 posixpath.join(remote, os.path.relpath(parent, local))


### PR DESCRIPTION
During the put operation of a folder, if the folder contains a symbolic link as a child, it is disregarded. 

With this small change, if a symbolic link is found, it is treated as a standard folder. 

Example folder structure: 
```
Project/
├── libs/
│   ├── libA
│   |   ├── file1.py
│   ├── libB
│   |   ├── file2.py
│   └── libC
│       └── file3.py
└── src/
    ├── main.py
    └── libs
          ├── libB*/
          └── libD/
              └── file4.py
```

Considering that the symbolic link is at __Project/src/libs/libB__ -> __Project/libB__, if folder __Project/src/libs__ is requested to be put at the board, only __libD__ folder was being uploaded till now. 
