### PR TITLE
reset: Do not wait for device messages after timeout

### DIFF
--- a/ampy/cli.py
+++ b/ampy/cli.py
@@ -408,7 +408,7 @@ def reset(mode):
         return
 
     try:
-        _board.exec_("reset()")
+        _board.exec_raw_no_follow("reset()")
     except serial.serialutil.SerialException as e:
         # An error is expected to occur, as the board should disconnect from
         # serial when restarted via microcontroller.reset()


### PR DESCRIPTION
The device is resetting and might not respond as expected. The user program might run after reset.
Do not wait for device reactions after the final reset call.

This fixes timeout exceptions such as:

```
Traceback (most recent call last):
  File "./ampy/cli.py", line 420, in <module>
    cli()
  File "/usr/lib/python3/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "./ampy/cli.py", line 411, in reset
    _board.exec_("reset()")
  File "/home/mb/develop/git/ampy/ampy/pyboard.py", line 265, in exec_
    ret, ret_err = self.exec_raw(command)
  File "/home/mb/develop/git/ampy/ampy/pyboard.py", line 257, in exec_raw
    return self.follow(timeout, data_consumer)
  File "/home/mb/develop/git/ampy/ampy/pyboard.py", line 221, in follow
    raise PyboardError('timeout waiting for first EOF reception')
ampy.pyboard.PyboardError: timeout waiting for first EOF reception
```