### PR TITLE
CLI: get and rm multiple files

### DIFF
--- a/ampy/cli.py
+++ b/ampy/cli.py
@@ -101,48 +101,65 @@ def cli(port, baud, delay):
 
 
 @cli.command()
-@click.argument("remote_file")
+@click.argument("remote_files", metavar="remote_file", nargs=-1)
 @click.argument(
     "local_path",
     type=click.Path(writable=True, allow_dash=True, path_type=pathlib.Path),
     required=False
 )
-def get(remote_file, local_path):
+def get(remote_files, local_path):
     """
     Retrieve a file from the board.
 
-    Get will download a file from the board and print its contents or save it
-    locally.  You must pass at least one argument which is the path to the file
-    to download from the board.  If you don't specify a second argument then
-    the file contents will be printed to standard output.  However if you pass
-    a file name or a directory as the second argument then the contents of the
-    downloaded file will be saved to that file or directory respectively
-    (overwriting anything inside it!).
+    Get will download one or more files from the board and print its contents or save it
+    locally.  You must pass at least one argument which is the path to a file
+    to download from the board.  If you specify more than one argument, the
+    last one is the destination.  If you specify exactly one remote file and
+    one local path, then the local path can either be a currently existing
+    directory or a destination file path.  If you specify more than one remote
+    file (i.e., three or more arguments), then the last argument must be a
+    local directory that exists.
+
+    If only one argument is specified, or if you pass in "-" as the second
+    argument, then the contents of the specified remote file will be printed to
+    standard output.  This is only available for one remote file.
+
+    Note: If the destination file exists, it will be overwritten!
 
     For example to retrieve the boot.py and print it out run:
 
       ampy --port /board/serial/port get boot.py
 
-    Or to get main.py and save it as main.py locally run:
-
-      ampy --port /board/serial/port get main.py ./
-
     You can also specify "-" as the destination to explicitly specify to output
     to standard output.
+
+    Or to get main.py and helper.py and save them in the current directory
+    locally, run:
+
+      ampy --port /board/serial/port get main.py helper.py ./
     """
-    # Get the file contents.
+    # checks
+    if len(remote_files) == 0:
+        raise click.UsageError("Must specify at least one remote file")
+    if len(remote_files) > 1 and not local_path.is_dir():
+        raise click.UsageError(
+                f"Invalid value for '[LOCAL_PATH]': Directory '{local_path}' does not exist.")
+
     board_files = files.Files(_board)
-    contents = board_files.get(remote_file)
-    # Print the file out if no local file was provided, otherwise save it.
-    if local_path is None or str(local_path) == "-":
-        print(contents.decode("utf-8"))
-    elif local_path.is_dir():
-        remote_path = pathlib.Path(remote_file)
-        with local_path.joinpath(remote_path.name).open(mode='wb') as local_file:
-            local_file.write(contents)
-    else:
-        with local_path.open(mode='wb') as local_file:
-            local_file.write(contents)
+    for remote_file in remote_files:
+        # Get the file contents.
+        contents = board_files.get(remote_file)
+
+        # Print the file out if no local file was provided, otherwise save it.
+        if local_path is None or str(local_path) == "-":
+            print(contents.decode("utf-8"))
+        elif local_path.is_dir():
+            remote_path = pathlib.Path(remote_file)
+            with local_path.joinpath(remote_path.name).open(mode='wb') as local_file:
+                local_file.write(contents)
+        else:
+            with local_path.open(mode='wb') as local_file:
+                local_file.write(contents)
 
 
 @cli.command()

--- a/ampy/cli.py
+++ b/ampy/cli.py
@@ -280,22 +280,21 @@ def put(local, remote):
 
 
 @cli.command()
-@click.argument("remote_file")
-def rm(remote_file):
-    """Remove a file from the board.
+@click.argument("remote_files", metavar="remote_file", nargs=-1)
+def rm(remote_files):
+    """Remove one or more files from the board.
 
-    Remove the specified file from the board's filesystem.  Must specify one
-    argument which is the path to the file to delete.  Note that this can't
-    delete directories which have files inside them, but can delete empty
+    Remove the specified file(s) from the board's filesystem.  Note that this
+    can't delete directories which have files inside them, but can delete empty
     directories.
 
-    For example to delete main.py from the root of a board run:
+    For example to delete main.py and data.txt from the root of a board run:
 
-      ampy --port /board/serial/port rm main.py
+      ampy --port /board/serial/port rm main.py data.txt
     """
-    # Delete the provided file/directory on the board.
     board_files = files.Files(_board)
-    board_files.rm(remote_file)
+    for filepath in remote_files:
+        board_files.rm(filepath)
 
 
 @cli.command()


### PR DESCRIPTION
# Description

This change is fairly simple

- `ampy rm`: be able to specify any number of files (note zero files is not an error, per recommendation by Python Click)
- `ampy get`: be able to specify a directory as the destination instead of a file
- `ampy get`: be able to specify multiple files from the remote, which will only work if the destination is a currently existing directory.
- `ampy get`: for one remote file, you can give `-` to explicitly specify writing to standard output.

## Related Work

I see this is somewhat similar to pull request #88.  If desired for `ampy get`, we could allow remote directories to be specified as well.  However, I think a destination directory would need to be specified as it becomes weird to print the contents of an entire directory to standard out.

### My recommendation:

- If a single remote directory is specified, then a destination must be required, either
    - an existing directory (in which the remote directory name will be created in the local existing directory), or
    - a non-existent path to be the path and name of the copied folder
- If multiple remote paths are given, nothing changes regardless of whether one or more of them are directories.  The current implementation in this pull request is that the destination must be an existing directory if multiple remote paths are specified.

### Questions

One tricky folder is the root folder, which has no name.

1. I think if multiple remote paths are specified and one of them is the root path, then that should be an error
2. If `/` is specified as the only remote path, then what do we do if the destination is a currently existing directory?  Here are a few options (I'm partial to solution (a)):
    a. Have it be an error - you must specify a directory that does not exist
    b. Copy all files and folders into that destination
    c. Create a hard-coded named directory in the destination called something like `pyboard_root` to copy stuff into.
3. Would we want to add a `--recursive`/`-r` flag to indicate that we do indeed want to copy a whole directory (if specified)?  Either way is fine with me.
4. Should this additional proposed change be a separate issue / pull request?


### Conclusion

This could allow for something like

```
ampy get -r / board_copy
```

to copy all files and folders and store them in a folder called `board_copy`