### PR TITLE
cli: make all variables found from environment variables

### DIFF
--- a/ampy/cli.py
+++ b/ampy/cli.py
@@ -55,11 +55,10 @@ def windows_full_port_name(portname):
         return "\\\\.\\{0}".format(portname)
 
 
-@click.group()
+@click.group(context_settings={'auto_envvar_prefix': 'AMPY'})
 @click.option(
     "--port",
     "-p",
-    envvar="AMPY_PORT",
     required=True,
     type=click.STRING,
     help="Name of serial port for connected board.  Can optionally specify with AMPY_PORT environment variable.",
@@ -68,7 +67,6 @@ def windows_full_port_name(portname):
 @click.option(
     "--baud",
     "-b",
-    envvar="AMPY_BAUD",
     default=115200,
     type=click.INT,
     help="Baud rate for the serial connection (default 115200).  Can optionally specify with AMPY_BAUD environment variable.",
@@ -77,7 +75,6 @@ def windows_full_port_name(portname):
 @click.option(
     "--delay",
     "-d",
-    envvar="AMPY_DELAY",
     default=0,
     type=click.FLOAT,
     help="Delay in seconds before entering RAW MODE (default 0). Can optionally specify with AMPY_DELAY environment variable.",


### PR DESCRIPTION
# Description

The python `click` module is pretty cool.  I've not seen in before this project and I like it.

One feature of `click` is to make every option and parameter able to be specified by an environment variable.

https://click.palletsprojects.com/en/8.0.x/options/?highlight=auto_envvar_prefix

This was a very simple change to make, but I've found it quite nice, especially with the extra command-line arguments I've been giving the commands like in PR #107 and PR #108, among others that I have done in my fork.